### PR TITLE
Change branch name for pyros

### DIFF
--- a/rosinstall/indigo-devel.rosinstall
+++ b/rosinstall/indigo-devel.rosinstall
@@ -1,3 +1,3 @@
 - git: {local-name: rostful, version: indigo-devel, uri: 'https://github.com/asmodehn/rostful.git'}
 - git: {local-name: rostful-examples, version: indigo-devel, uri: 'https://github.com/asmodehn/rostful-examples.git'}
-- git: {local-name: pyros, version: indigo-devel, uri: 'https://github.com/asmodehn/pyros.git'}
+- git: {local-name: pyros, version: indigo, uri: 'https://github.com/asmodehn/pyros.git'}


### PR DESCRIPTION
Changed pyros branch used in indigo-devel.rosinstall as the specified branch for pyros (eg: indigo-devel) no longer exist.